### PR TITLE
Fix typo in "utilities" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This increases the chance that we might be able to use your contribution (or it 
 
 ## Running a standalone server
 
-Local development support is provided for all platforms - Windows, macOS, Linux - by ServerStandAlone - a .NET Core MVC Web App, and the command line apps in the Data Utilites folder.
+Local development support is provided for all platforms - Windows, macOS, Linux - by ServerStandAlone - a .NET Core MVC Web App, and the command line apps in the Data Utilities folder.
 
 ## Development Tools
 


### PR DESCRIPTION
Noticed a small typo in the README. This PR changes "Utilites" to "Utilities".