### PR TITLE
Fix broken Dockerfile

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -25,12 +25,15 @@ The `Tools` folder has all the available tools. For updating the app config for 
 Run `docker exec docker_content_api_1 Tools/DbProvision/DbProvision`
 
 ### Appconfig and risk parameter setup
-Run `docker exec docker_content_api_1 Tools/DbFillExampleContent/DbFillExampleContent`
+Run `docker exec docker_content_api_1 Tools/DbFillExampleContent/PublishContent -a Tools/DbFillExampleContent/appconfig.json`
+and `docker exec docker_content_api_1 Tools/DbFillExampleContent/PublishContent -r Tools/DbFillExampleContent/riskparams.json`
 
 ### Manifest generation
 Run `docker exec docker_content_api_1 ManifestEngine/ManifestEngine`
 
 ### Eks generation
-Run `docker exec docker_content_api_1 EksEngine/EksEngine`
+Run `docker exec docker_content_api_1 Tools/GenTeks/GenTeks`
+and `docker exec docker_content_api_1 Tools/ForceTekAuth/ForceTekAuth`
+and `docker exec docker_content_api_1 EksEngine/EksEngine`
 
 **Please be aware of the 'quickstart development'-only semi-secrets in `docker/**/*`, the Docker configuration has no intentions to be used in publicly available testing, acceptation or production environments.**

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.1-alpine AS builder
 COPY . app/
 WORKDIR app/
 COPY docker/development/appsettings.json .
-RUN rm Components/Framework/WindowsIdentityStuff.cs
+RUN rm -f Components/Framework/WindowsIdentityStuff.cs
 COPY docker/development/hacks/WindowsIdentityStuff.cs Components/Framework/
 
 # get rid of xcopy commands in project files
@@ -15,7 +15,7 @@ RUN dotnet publish EksEngine/EksEngine.csproj --no-self-contained  --configurati
 RUN dotnet publish ManifestEngine/ManifestEngine.csproj --no-self-contained  --configuration Release -o publish/ManifestEngine --version-suffix local
 
 RUN dotnet publish DbProvision/DbProvision.csproj --no-self-contained  --configuration Release -o publish/Tools/DbProvision --version-suffix local
-RUN dotnet publish DbFillExampleContent/DbFillExampleContent.csproj --no-self-contained  --configuration Release -o publish/Tools/DbFillExampleContent --version-suffix local
+RUN dotnet publish PublishContent/PublishContent.csproj --no-self-contained  --configuration Release -o publish/Tools/DbFillExampleContent --version-suffix local
 RUN dotnet publish GenTeks/GenTeks.csproj --no-self-contained  --configuration Release -o publish/Tools/GenTeks --version-suffix local
 RUN dotnet publish ForceTekAuth/ForceTekAuth.csproj --no-self-contained  --configuration Release -o publish/Tools/ForceTekAuth --version-suffix local
 


### PR DESCRIPTION
A couple of minor issues were preventing the Dockerfile from working with docker-compose on a clean install.

1. The `WindowsIdentityStuff.cs` only exists after a working run, so the removal of the file was failing. The `rm` is now forced to avoid the error.

2. The `DbFillExampleContent` project was moved to `PublishContent` in commit 2dd0ce4b3110ea64388ef533b199d284fc27f6d1 and the Dockerfile needed updating to reflect this.

This PR is to address #25  @skos001 @dirkx .