### PR TITLE
Work around certificate exceptions on Docker/Linux

### DIFF
--- a/Components/ExposureKeySetsEngine/FormatV1/EksBuilderV1.cs
+++ b/Components/ExposureKeySetsEngine/FormatV1/EksBuilderV1.cs
@@ -62,8 +62,28 @@ namespace NL.Rijksoverheid.ExposureNotification.BackEnd.Components.ExposureKeySe
             };
 
             var contentBytes = _EksContentFormatter.GetBytes(content);
-            var nlSig = _NlContentSigner.GetSignature(contentBytes);
-            var gaenSig = _GaenContentSigner.GetSignature(contentBytes);
+
+            byte[] nlSig;
+            try
+            {
+              nlSig = _NlContentSigner.GetSignature(contentBytes);
+            }
+            catch
+            {
+              nlSig = new byte[] { 0x4e, 0x6f, 0x53, 0x69, 0x67 };
+              _Logger.LogWarning("NL Siganture could not be generated, using dummy value");
+            }
+
+            byte[] gaenSig;
+            try
+            {
+              gaenSig = _GaenContentSigner.GetSignature(contentBytes);
+            }
+            catch
+            {
+              gaenSig = new byte[] { 0x4e, 0x6f, 0x53, 0x69, 0x67 };
+              _Logger.LogWarning("GAEN Siganture could not be generated, using dummy value");
+            }
 
             _Logger.LogDebug("GAEN Sig: {Convert.ToBase64String(GaenSig)}.", gaenSig);
             _Logger.LogDebug("NL Sig: {Convert.ToBase64String(NlSig)}.", nlSig);

--- a/Components/Framework/WindowsIdentityQueries.cs
+++ b/Components/Framework/WindowsIdentityQueries.cs
@@ -10,9 +10,16 @@ namespace NL.Rijksoverheid.ExposureNotification.BackEnd.Components.Framework
     {
         public static bool CurrentUserIsAdministrator()
         {
-            var identity = WindowsIdentity.GetCurrent();
-            var principal = new WindowsPrincipal(identity);
-            return principal.IsInRole(WindowsBuiltInRole.Administrator);
+            try
+            {
+                var identity = WindowsIdentity.GetCurrent();
+                var principal = new WindowsPrincipal(identity);
+                return principal.IsInRole(WindowsBuiltInRole.Administrator);
+            }
+            catch
+            {
+                return false;
+            }
         }
     }
 }


### PR DESCRIPTION
The user certificate store isn't available on Linux, resulting in an error that prevents the exposure key set from being published when running in a Docker container on Linux.

These changes don't fix the problem, but simply work around it by catching the exceptions and forcing the use of a dummy signature instead.
