### PR TITLE
Fixes to allow running the development docker environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Local development support is provided for all platforms - Windows, macOS, Linux 
 To quickly start a local Standalone development environment for app testing purposes you can use of the docker-compose file:
 ```bash
 # Solution root
-cd docker
-docker-compose up --build
+# Run in project root:
+docker-compose -f docker/docker-compose.yml up -d --build
 ``` 
 **Please be aware of the 'quickstart development'-only semi-secrets in `docker/**/*`, the Docker configuration has no intentions to be used in publicly available testing, acceptation or production environments.**
 

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.1-alpine AS builder
 COPY . app/
 WORKDIR app/
 COPY docker/development/appsettings.json .
-RUN rm Components/Framework/WindowsIdentityStuff.cs
+RUN if [[ -f Components/Framework/WindowsIdentityStuff.cs ]]; then rm Components/Framework/WindowsIdentityStuff.cs; fi
 COPY docker/development/hacks/WindowsIdentityStuff.cs Components/Framework/
 
 # get rid of xcopy commands in project files
@@ -15,7 +15,8 @@ RUN dotnet publish EksEngine/EksEngine.csproj --no-self-contained  --configurati
 RUN dotnet publish ManifestEngine/ManifestEngine.csproj --no-self-contained  --configuration Release -o publish/ManifestEngine --version-suffix local
 
 RUN dotnet publish DbProvision/DbProvision.csproj --no-self-contained  --configuration Release -o publish/Tools/DbProvision --version-suffix local
-RUN dotnet publish DbFillExampleContent/DbFillExampleContent.csproj --no-self-contained  --configuration Release -o publish/Tools/DbFillExampleContent --version-suffix local
+# Due to project constraints this project has been removed
+# RUN dotnet publish DbFillExampleContent/DbFillExampleContent.csproj --no-self-contained  --configuration Release -o publish/Tools/DbFillExampleContent --version-suffix local
 RUN dotnet publish GenTeks/GenTeks.csproj --no-self-contained  --configuration Release -o publish/Tools/GenTeks --version-suffix local
 RUN dotnet publish ForceTekAuth/ForceTekAuth.csproj --no-self-contained  --configuration Release -o publish/Tools/ForceTekAuth --version-suffix local
 


### PR DESCRIPTION
Following the guidelines the development environment could not be started. This was due to the following issues:
- The command for starting the docker-based environment mentioned the wrong startup folder (it now also daemonizes the containers)
- A file to remove did not exists (this is now guarded)
- The sample data repository is no longer there